### PR TITLE
metadata.FromContext is replaced by metadata.FromIncomingContext

### DIFF
--- a/hello_interceptor/server/main.go
+++ b/hello_interceptor/server/main.go
@@ -65,7 +65,7 @@ func main() {
 
 // auth 验证Token
 func auth(ctx context.Context) error {
-	md, ok := metadata.FromContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return grpc.Errorf(codes.Unauthenticated, "无Token认证信息")
 	}

--- a/hello_token/server/main.go
+++ b/hello_token/server/main.go
@@ -28,7 +28,7 @@ var HelloService = helloService{}
 // SayHello 实现Hello服务接口
 func (h helloService) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloResponse, error) {
 	// 解析metada中的信息并验证
-	md, ok := metadata.FromContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return nil, grpc.Errorf(codes.Unauthenticated, "无Token认证信息")
 	}


### PR DESCRIPTION
metadata.FromContext 不再使用  被分成了 metadata.FromIncomingContext 和 metadate.FromOutcomingContext 。 这里应该使用metadata.FromIncomingContext。
讨论连接 https://github.com/GoogleCloudPlatform/google-cloud-go/issues/624